### PR TITLE
Give logos in testimonials fixed sizes

### DIFF
--- a/src/components/HomeSectionTestimonials/index.tsx
+++ b/src/components/HomeSectionTestimonials/index.tsx
@@ -26,10 +26,10 @@ const HomeSectionTestimonials = () => (
       </BlockquoteFooter>
     </Blockquote>
     <Logos>
-      <Logo src={fatLlamaLogo} />
-      <Logo src={googleLogo} />
-      <Logo src={commonLogo} />
-      <Logo src={framerLogo} />
+      <Logo src={fatLlamaLogo} width="127" height="62" />
+      <Logo src={googleLogo} width="148" height="62" />
+      <Logo src={commonLogo} width="284" height="62" />
+      <Logo src={framerLogo} width="60" height="62" />
     </Logos>
   </Container>
 );


### PR DESCRIPTION
To prevent them from jumping when loading.