### PR TITLE
Instead of `forceBreakAfter`, re-order column items to make a proper split

### DIFF
--- a/src/pages-styled/content.styled.ts
+++ b/src/pages-styled/content.styled.ts
@@ -60,22 +60,12 @@ export const SectionHeader = styled(_Separator)`
   `}
 `;
 
-interface ItemLinkProps {
-  forceBreakAfter?: boolean;
-}
-
 export const ItemLink = styled(Link)`
   display: block;
   border: none;
   margin-bottom: ${gridSize * 4}px;
   page-break-inside: avoid;
   break-inside: avoid;
-
-  ${(props: ItemLinkProps) =>
-    props.forceBreakAfter &&
-    css`
-      break-after: column;
-    `}
 `;
 
 export const ItemTitle = styled.div`

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -38,7 +38,6 @@ interface ContentItemProps {
   description?: string | JSXChildrenProp;
   link: string;
   isNew?: boolean;
-  forceBreakAfter?: boolean;
 }
 const ContentItem = ({
   image,
@@ -46,10 +45,9 @@ const ContentItem = ({
   description,
   link,
   isNew,
-  forceBreakAfter,
 }: ContentItemProps) => {
   return (
-    <ItemLink to={link} forceBreakAfter={forceBreakAfter}>
+    <ItemLink to={link}>
       {image && (
         <ItemImage>
           <GatsbyImage fixed={image.childImageSharp.fixed} />
@@ -113,7 +111,10 @@ const ContentPage = (props: ContentPageProps) => {
               link="https://iamakulov.com/notes/walmart/"
               title="Case study: Analyzing the Walmart site performance"
               description="A deep-dive into improving Walmart’s site speed and conversion"
-              forceBreakAfter
+            />
+            <ContentItem
+              link="/blog/link-rels/"
+              title="Preload, prefetch and other <link> tags"
             />
             <ContentItem
               link="https://developers.google.com/web/fundamentals/performance/webpack/"
@@ -131,10 +132,6 @@ const ContentPage = (props: ContentPageProps) => {
             <ContentItem
               link="https://iamakulov.com/notes/polished-webpack/"
               title="Case study: Improving a popular library’s size for webpack users"
-            />
-            <ContentItem
-              link="/blog/link-rels/"
-              title="Preload, prefetch and other <link> tags"
             />
             <ContentItem
               link="/blog/polyfills/"


### PR DESCRIPTION
For some reason, `break-after: column` hides the second column completely on narrow screens (at least, in Chromium).