### PR TITLE
Gatsby: Add a custom Markdown transformer to fine-tune the markdown output

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -91,6 +91,7 @@ module.exports = {
               },
             },
           },
+          `gatsby-remark-3perf-transformer`,
         ],
       },
     },

--- a/plugins/gatsby-remark-3perf-transformer/index.js
+++ b/plugins/gatsby-remark-3perf-transformer/index.js
@@ -1,0 +1,19 @@
+const visit = require('unist-util-visit');
+
+module.exports = ({ markdownAST }, pluginOptions) => {
+  // Add a <div class="table-container"> wrapper around each table
+  visit(markdownAST, 'table', (node, index, parent) => {
+    const wrapper = {
+      type: 'TableContainer',
+      data: {
+        hName: 'div',
+        hProperties: { className: 'table-container' },
+      },
+      children: [node],
+    };
+
+    parent.children[index] = wrapper;
+  });
+
+  return markdownAST;
+};

--- a/plugins/gatsby-remark-3perf-transformer/package.json
+++ b/plugins/gatsby-remark-3perf-transformer/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "gatsby-remark-3perf-transformer",
+  "version": "1.0.0",
+  "private": true
+}


### PR DESCRIPTION
Right now, the transformer simply wraps tables into `.table-container` (this helps to add custom styles – like an overflow scrollbar).

Further plans:
* In the `[[sidenote]]` block, switch the DOM order of `title` and `body`. The `title` (which is the actual sidenote, in this case) should come _after_ the `body` to make sure RSS readers render it in the right order.
* In the `[[sidenote]]` block, make `title` an `em` to make sure it’s highlighted differently in RSS readers