### PR TITLE
Netlify: Enable the Gatsby build plugin

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[build]
+publish = "public"
+
+[[plugins]]
+package = "netlify-plugin-gatsby-cache"


### PR DESCRIPTION
This should help to speed up builds (by not regenerating images every time).