### PR TITLE
Fix Google Analytics

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -122,17 +122,6 @@ module.exports = {
       },
     },
     {
-      resolve: `gatsby-plugin-google-gtag`,
-      options: {
-        trackingIds: ['UA-38017504-7'],
-        gtagConfig: {
-          linker: {
-            domains: ['3perf.com', 'googlefonts.3perf.com'],
-          },
-        },
-      },
-    },
-    {
       resolve: `gatsby-plugin-feed`,
       options: {
         query: `

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "gatsby": "^2.0.72",
     "gatsby-image": "^2.0.25",
     "gatsby-link": "^2.0.16",
-    "gatsby-plugin-google-gtag": "^1.0.16",
     "invariant": "^2.2.4",
     "lodash": "^4.17.15",
     "polished": "^3.4.4",

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -80,11 +80,35 @@ class Layout extends React.Component<LayoutProps, {}> {
         <GlobalStyle />
         {children}
         <Script
+          async
+          src="https://www.googletagmanager.com/gtag/js?id=UA-38017504-7"
+        />
+        <Script
+          dangerouslySetInnerHTML={{
+            __html: `
+              if (window.location.hostname === 'localhost') {
+                // Disable GA on localhost, per https://stackoverflow.com/a/45367051/1192426
+                window['ga-disable-UA-38017504-7'] = true;
+              }
+            `,
+          }}
+        />
+        <Script
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+
+              gtag('config', 'UA-38017504-7');
+            `,
+          }}
+        />
+        <Script
           src="https://cdnjs.cloudflare.com/ajax/libs/quicklink/2.0.0-alpha/quicklink.umd.js"
           defer
         />
         <Script
-          data-no-instant
           dangerouslySetInnerHTML={{
             __html: `
               window.addEventListener('load', () => quicklink.listen());

--- a/yarn.lock
+++ b/yarn.lock
@@ -6593,14 +6593,6 @@ gatsby-plugin-feed@^2.0.15:
     lodash.merge "^4.6.2"
     rss "^1.2.2"
 
-gatsby-plugin-google-gtag@^1.0.16:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-1.2.1.tgz#5d5903531abcff11193ee1977db9552d5133b1c6"
-  integrity sha512-cJHvDL6IVnj/XfgMhSa6DTOobO3XAZuatcDD1FrkKgj4pytUoHbIY8lFO4TztjMfLv98F302K23NPzYlSaN05A==
-  dependencies:
-    "@babel/runtime" "^7.8.7"
-    minimatch "^3.0.4"
-
 gatsby-plugin-lodash@^3.0.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-lodash/-/gatsby-plugin-lodash-3.2.1.tgz#32ff4a026888d771143a7e1e12cb4d5f6a9d6772"


### PR DESCRIPTION
GA stopped working after #1 was deployed – i.e., starting with May 30th. What a pity.

Apparently, `gatsby-plugin-google-gtag` relies on the Gatsby bundle code – which we’re removing with `gatsby-plugin-no-javascript`.