### PR TITLE
Enlarge and condense headings

### DIFF
--- a/src/components/Layout/GlobalStyle.tsx
+++ b/src/components/Layout/GlobalStyle.tsx
@@ -28,6 +28,16 @@ export const GlobalStyle = createGlobalStyle`
     overflow: hidden;
   }
 
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: 'Bricolage Grotesque Variable', sans-serif;
+    font-stretch: 70%;
+  }
+
   a {
     ${linkStyles}
   }

--- a/src/components/Layout/GlobalStyle.tsx
+++ b/src/components/Layout/GlobalStyle.tsx
@@ -35,7 +35,7 @@ export const GlobalStyle = createGlobalStyle`
   h5,
   h6 {
     font-family: 'Bricolage Grotesque Variable', sans-serif;
-    font-stretch: 75%;
+    font-stretch: 85%;
   }
 
   a {

--- a/src/components/Layout/GlobalStyle.tsx
+++ b/src/components/Layout/GlobalStyle.tsx
@@ -35,7 +35,7 @@ export const GlobalStyle = createGlobalStyle`
   h5,
   h6 {
     font-family: 'Bricolage Grotesque Variable', sans-serif;
-    font-stretch: 70%;
+    font-stretch: 75%;
   }
 
   a {

--- a/src/components/talks/SectionHeader/styled.ts
+++ b/src/components/talks/SectionHeader/styled.ts
@@ -8,12 +8,12 @@ export const Link = styled.a`
   border: none;
   position: relative;
 
-  font-size: 60px;
+  font-size: 80px;
   font-weight: bold;
   white-space: nowrap;
 
   ${media.small`
-    font-size: 48px;
+    font-size: 64px;
     white-space: normal;
     line-height: 1;
   `};

--- a/src/components/talks/SectionHeader/styled.ts
+++ b/src/components/talks/SectionHeader/styled.ts
@@ -8,12 +8,12 @@ export const Link = styled.a`
   border: none;
   position: relative;
 
-  font-size: 80px;
+  font-size: 72px;
   font-weight: bold;
   white-space: nowrap;
 
   ${media.small`
-    font-size: 64px;
+    font-size: 60px;
     white-space: normal;
     line-height: 1;
   `};

--- a/src/components/talks/TalkHeader/styled.ts
+++ b/src/components/talks/TalkHeader/styled.ts
@@ -18,13 +18,13 @@ export const Image = styled(GatsbyImage)`
 `;
 
 export const Title = styled.h1<{ $hasSubtitle: boolean }>`
-  font-size: 2em;
+  font-size: 2.6667em;
   line-height: 1.2;
   margin-top: ${gridSize * 4}px;
   margin-bottom: ${gridSize * 2}px;
 
   ${media.small`
-    font-size: 1.5em;
+    font-size: 2em;
   `}
 `;
 

--- a/src/components/talks/TalkHeader/styled.ts
+++ b/src/components/talks/TalkHeader/styled.ts
@@ -18,13 +18,13 @@ export const Image = styled(GatsbyImage)`
 `;
 
 export const Title = styled.h1<{ $hasSubtitle: boolean }>`
-  font-size: 2.6667em;
+  font-size: 48px;
   line-height: 1;
   margin-top: ${gridSize * 4}px;
   margin-bottom: ${gridSize * 2}px;
 
   ${media.small`
-    font-size: 2em;
+    font-size: 36px;
   `}
 `;
 

--- a/src/components/talks/TalkHeader/styled.ts
+++ b/src/components/talks/TalkHeader/styled.ts
@@ -19,7 +19,7 @@ export const Image = styled(GatsbyImage)`
 
 export const Title = styled.h1<{ $hasSubtitle: boolean }>`
   font-size: 2.6667em;
-  line-height: 1.2;
+  line-height: 1;
   margin-top: ${gridSize * 4}px;
   margin-bottom: ${gridSize * 2}px;
 

--- a/src/pages/404.styled.ts
+++ b/src/pages/404.styled.ts
@@ -17,12 +17,12 @@ export const Content = styled.div`
 
 export const Header = styled.h1`
   color: ${colors.brightYellow};
-  font-size: 48px;
+  font-size: 42px;
   font-weight: 900;
   margin: ${gridSize * 8}px 0 ${gridSize * 3}px;
 
   ${media.notSmall`
-    font-size: 80px;
+    font-size: 72px;
     margin-top: ${gridSize * 16}px;
   `}
 `;

--- a/src/pages/404.styled.ts
+++ b/src/pages/404.styled.ts
@@ -17,12 +17,12 @@ export const Content = styled.div`
 
 export const Header = styled.h1`
   color: ${colors.brightYellow};
-  font-size: 36px;
+  font-size: 48px;
   font-weight: 900;
   margin: ${gridSize * 8}px 0 ${gridSize * 3}px;
 
   ${media.notSmall`
-    font-size: 60px;
+    font-size: 80px;
     margin-top: ${gridSize * 16}px;
   `}
 `;

--- a/src/pages/index.styled.ts
+++ b/src/pages/index.styled.ts
@@ -28,7 +28,7 @@ export const Nav = styled(_Nav)`
 
 export const Header = styled.h1`
   margin: ${gridSize * 8}px 0 ${gridSize * 4}px;
-  font-size: 90px;
+  font-size: 72px;
   line-height: 0.85;
   color: ${colors.brightYellow};
   font-weight: 900;
@@ -40,7 +40,7 @@ export const Header = styled.h1`
   -webkit-text-fill-color: transparent;
 
   ${media.small`
-    font-size: 48px;
+    font-size: 42px;
     margin-bottom: ${gridSize * 2}px;
   `}
 `;
@@ -56,7 +56,7 @@ export const SectionDateView = styled.div`
 
 export const DateYearHeader = styled.h3`
   margin: ${gridSize * 6}px 0 ${gridSize * 3}px;
-  font-size: 48px;
+  font-size: 42px;
   font-weight: bold;
   line-height: 1;
   color: ${colors.brightYellow};
@@ -66,18 +66,18 @@ export const DateYearHeader = styled.h3`
   }
 
   ${media.small`
-    font-size: 37.3333px;
+    font-size: 36px;
   `}
 `;
 
 export const SectionHeader = styled.h2`
   margin: ${gridSize * 8}px 0 ${gridSize * 4}px;
-  font-size: 64px;
+  font-size: 60px;
   font-weight: bold;
   line-height: 1;
 
   ${media.small`
-    font-size: 48px;
+    font-size: 42px;
   `}
 `;
 

--- a/src/pages/index.styled.ts
+++ b/src/pages/index.styled.ts
@@ -28,8 +28,8 @@ export const Nav = styled(_Nav)`
 
 export const Header = styled.h1`
   margin: ${gridSize * 8}px 0 ${gridSize * 4}px;
-  font-size: 80px;
-  line-height: 1.2;
+  font-size: 90px;
+  line-height: 0.85;
   color: ${colors.brightYellow};
   font-weight: 900;
 

--- a/src/pages/index.styled.ts
+++ b/src/pages/index.styled.ts
@@ -28,7 +28,7 @@ export const Nav = styled(_Nav)`
 
 export const Header = styled.h1`
   margin: ${gridSize * 8}px 0 ${gridSize * 4}px;
-  font-size: 60px;
+  font-size: 80px;
   line-height: 1.2;
   color: ${colors.brightYellow};
   font-weight: 900;
@@ -40,7 +40,7 @@ export const Header = styled.h1`
   -webkit-text-fill-color: transparent;
 
   ${media.small`
-    font-size: 36px;
+    font-size: 48px;
     margin-bottom: ${gridSize * 2}px;
   `}
 `;
@@ -56,7 +56,7 @@ export const SectionDateView = styled.div`
 
 export const DateYearHeader = styled.h3`
   margin: ${gridSize * 6}px 0 ${gridSize * 3}px;
-  font-size: 36px;
+  font-size: 48px;
   font-weight: bold;
   line-height: 1;
   color: ${colors.brightYellow};
@@ -66,18 +66,18 @@ export const DateYearHeader = styled.h3`
   }
 
   ${media.small`
-    font-size: 28px;
+    font-size: 37.3333px;
   `}
 `;
 
 export const SectionHeader = styled.h2`
   margin: ${gridSize * 8}px 0 ${gridSize * 4}px;
-  font-size: 48px;
+  font-size: 64px;
   font-weight: bold;
   line-height: 1;
 
   ${media.small`
-    font-size: 36px;
+    font-size: 48px;
   `}
 `;
 

--- a/src/pages/workshops/styled.ts
+++ b/src/pages/workshops/styled.ts
@@ -41,7 +41,7 @@ export const Nav = styled(_Nav)`
 export const Header = styled.h1`
   margin: 0 0 ${gridSize * 3}px;
   font-size: 4em;
-  line-height: 1.2;
+  line-height: 0.85;
   font-weight: 900;
   color: ${colors.brightYellow};
 `;

--- a/src/pages/workshops/styled.ts
+++ b/src/pages/workshops/styled.ts
@@ -40,10 +40,14 @@ export const Nav = styled(_Nav)`
 
 export const Header = styled.h1`
   margin: 0 0 ${gridSize * 3}px;
-  font-size: 4em;
+  font-size: 72px;
   line-height: 0.85;
   font-weight: 900;
   color: ${colors.brightYellow};
+
+  ${media.small`
+    font-size: 60px;
+  `}
 `;
 
 export const FooterContainer = styled.div`

--- a/src/pages/workshops/styled.ts
+++ b/src/pages/workshops/styled.ts
@@ -40,7 +40,7 @@ export const Nav = styled(_Nav)`
 
 export const Header = styled.h1`
   margin: 0 0 ${gridSize * 3}px;
-  font-size: 3em;
+  font-size: 4em;
   line-height: 1.2;
   font-weight: 900;
   color: ${colors.brightYellow};

--- a/src/templates/blog/styled.ts
+++ b/src/templates/blog/styled.ts
@@ -29,12 +29,12 @@ export const BottomMeta = styled.div`
 
 export const Title = styled.h1`
   margin: 0;
-  font-size: 60px;
+  font-size: 80px;
   font-weight: 900;
   line-height: 1;
 
   ${media.small`
-    font-size: 40px;
+    font-size: 53.3333px;
   `}
 `;
 
@@ -75,16 +75,16 @@ const headerStyles = css`
   }
 
   h1 {
-    font-size: 32px;
+    font-size: 42.6667px;
     font-weight: 900;
   }
 
   h2 {
-    font-size: 24px;
+    font-size: 32px;
   }
 
   h3 {
-    font-size: 18px;
+    font-size: 24px;
   }
 `;
 

--- a/src/templates/blog/styled.ts
+++ b/src/templates/blog/styled.ts
@@ -20,7 +20,7 @@ export const Header = styled.header`
 `;
 
 export const TopMeta = styled.div`
-  margin-top: ${gridSize * 2}px;
+  margin-top: ${gridSize * 3}px;
 `;
 
 export const BottomMeta = styled.div`
@@ -31,7 +31,7 @@ export const Title = styled.h1`
   margin: 0;
   font-size: 80px;
   font-weight: 900;
-  line-height: 1;
+  line-height: 0.85;
 
   ${media.small`
     font-size: 53.3333px;

--- a/src/templates/blog/styled.ts
+++ b/src/templates/blog/styled.ts
@@ -29,12 +29,12 @@ export const BottomMeta = styled.div`
 
 export const Title = styled.h1`
   margin: 0;
-  font-size: 80px;
+  font-size: 72px;
   font-weight: 900;
   line-height: 0.85;
 
   ${media.small`
-    font-size: 53.3333px;
+    font-size: 48px;
   `}
 `;
 
@@ -75,12 +75,12 @@ const headerStyles = css`
   }
 
   h1 {
-    font-size: 42.6667px;
+    font-size: 36px;
     font-weight: 900;
   }
 
   h2 {
-    font-size: 32px;
+    font-size: 30px;
   }
 
   h3 {

--- a/src/templates/legal/styled.ts
+++ b/src/templates/legal/styled.ts
@@ -26,12 +26,12 @@ export const RelatedLinks = styled.div`
 
 export const Title = styled.h1`
   margin: 0;
-  font-size: 80px;
+  font-size: 72px;
   font-weight: 900;
   line-height: 1;
 
   ${media.small`
-    font-size: 53.3333px;
+    font-size: 48px;
   `}
 `;
 
@@ -60,12 +60,12 @@ const headerStyles = css`
   }
 
   h1 {
-    font-size: 42.6667px;
+    font-size: 36px;
     font-weight: 900;
   }
 
   h2 {
-    font-size: 32px;
+    font-size: 30px;
   }
 
   h3 {

--- a/src/templates/legal/styled.ts
+++ b/src/templates/legal/styled.ts
@@ -26,12 +26,12 @@ export const RelatedLinks = styled.div`
 
 export const Title = styled.h1`
   margin: 0;
-  font-size: 60px;
+  font-size: 80px;
   font-weight: 900;
   line-height: 1;
 
   ${media.small`
-    font-size: 40px;
+    font-size: 53.3333px;
   `}
 `;
 
@@ -60,16 +60,16 @@ const headerStyles = css`
   }
 
   h1 {
-    font-size: 32px;
+    font-size: 42.6667px;
     font-weight: 900;
   }
 
   h2 {
-    font-size: 24px;
+    font-size: 32px;
   }
 
   h3 {
-    font-size: 18px;
+    font-size: 24px;
   }
 `;
 


### PR DESCRIPTION
## What changed

- apply Bricolage Grotesque and `font-stretch: 85%` to every semantic heading
- make each existing heading 20% larger than its `master` baseline, rounded to the nearest 6 px
- preserve the existing heading hierarchy, responsive breakpoints, and the branch’s later line-spacing refinements

## Impact

Headings are moderately larger and condensed throughout the site while body typography and non-heading content remain unchanged.

## Validation

- `yarn prettier --check` on all changed files
- `yarn eslint` on all changed files
- production build intentionally skipped per request because it overloads the development machine
